### PR TITLE
Update operational data on port link speed change

### DIFF
--- a/zbx_export_templates.yaml
+++ b/zbx_export_templates.yaml
@@ -3432,7 +3432,7 @@ zabbix_export:
               expression: 'last(/Unifi Switch/connection_speed_[{#PORT_IDX}],#2)>0 and last(/Unifi Switch/connection_speed_[{#PORT_IDX}],#1)>0 and last(/Unifi Switch/up_[{#PORT_IDX}],#1)="true" and last(/Unifi Switch/stp_state_[{#PORT_IDX}],#1)="forwarding" and (last(/Unifi Switch/connection_speed_[{#PORT_IDX}],#1) <> last(/Unifi Switch/connection_speed_[{#PORT_IDX}],#2))'
               recovery_mode: NONE
               name: '{{#PORT_IS_UPLINK}.regsub("true", "Uplink")} {{#PORT_MEDIA}.regsub("SFP", \0)} Port {#PORT_IDX} has changed Connection Speed'
-              opdata: 'last(/Unifi Switch/connection_speed_[{#PORT_IDX}],#1)'
+              opdata: 'Link speed on port {#PORT_IDX} changed to {ITEM.VALUE1}'
               priority: INFO
               description: 'Might indicate bad wiring, or just a new device with a different interface being connected'
               manual_close: 'YES'


### PR DESCRIPTION
From zabbix docs on operational data:

> Supported [macros](https://www.zabbix.com/documentation/current/en/manual/appendix/macros/supported_by_location) are: {HOST.HOST}, {HOST.NAME}, {HOST.PORT}, {HOST.CONN}, {HOST.DNS}, {HOST.IP}, {ITEM.VALUE}, {ITEM.LASTVALUE}, {ITEM.LOG.*} and {$MACRO} user macros.
> $1, $2...$9 macros can be used to refer to the first, second...ninth constant of the expression.

https://www.zabbix.com/documentation/current/en/manual/config/triggers/trigger

Current optada value does not parse on my instance of zabbix 6.2.7:
![obraz](https://user-images.githubusercontent.com/67835103/223367812-cf017643-f8e7-4ac3-87e2-020aa8e793d2.png)

PS. I think all opdata in the template should be changed accordingly