### PR TITLE
The Unifi USG template encountered an issue with my USG device due to…

### DIFF
--- a/mca-dump-short.sh
+++ b/mca-dump-short.sh
@@ -401,7 +401,7 @@ function invokeMcaDump() {
 	
 	#shellcheck disable=SC2086
 	output=$(timeout --signal=HUP --kill-after=5 "${TIMEOUT}" \
-		${SSHPASS_OPTIONS} ssh ${SSH_PORT} ${VERBOSE_SSH} ${HE_RSA_SSH_KEY_OPTIONS} ${BATCH_MODE} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o StrictHostKeyChecking=accept-new ${PRIVKEY_OPTION} "${USER}@${TARGET_DEVICE}" ${delay:+sleep ${delay}\;} mca-dump 2>&1	)
+		${SSHPASS_OPTIONS} ssh ${SSH_PORT} ${VERBOSE_SSH} ${HE_RSA_SSH_KEY_OPTIONS} ${BATCH_MODE} -o LogLevel=Error -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o StrictHostKeyChecking=accept-new ${PRIVKEY_OPTION} "${USER}@${TARGET_DEVICE}" ${delay:+sleep ${delay}\;} mca-dump 2>&1	)
 	exitCode=$?
 	#shellcheck disable=SC2034
 	jsonOutput="${output}"


### PR DESCRIPTION
… the SSH login welcome message interfering with the JSON output from the mca-dump command. This welcome message, which appears before the actual JSON data, was causing the script to fail when attempting to parse the mca-dump output as valid JSON.